### PR TITLE
fix: get singularity to work correctly again

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -30,13 +30,12 @@ services:
       - 27017:27017
     volumes:
       - ${MOTION_HOME:-$HOME/.motion}/zenko/mongodbMetadata:/data/db
-      - ./mongod.conf:/etc/mongod.conf
-#    healthcheck:
-#      test: mongo --eval 'db.runCommand("ping").ok' localhost:27017/${MONGODB_DATABASE:-metadata} --quiet
-#      interval: 10s
-#      timeout: 5s
-#      retries: 10
-#      start_period: 30s
+    healthcheck:
+      test: mongo --eval 'db.runCommand("ping").ok' localhost:27017/${MONGODB_DATABASE:-metadata} --quiet
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
 
   singularity_admin_init:
     image: ghcr.io/data-preservation-programs/singularity:${SINGULARITY_VERSION:-v0.5.9}
@@ -54,18 +53,18 @@ services:
 
   singularity_api:
     image: ghcr.io/data-preservation-programs/singularity:${SINGULARITY_VERSION:-v0.5.9}
-    command: run api --bind :9091
+    command: run api --bind :9090
     volumes:
       - motion-singularity-volume:/usr/src/app/storage
     ports:
-      - 9091:9091
+      - 9090:9090
     environment:
       DATABASE_CONNECTION_STRING: postgres://${SINGULARITY_DB_USER:-postgres}:${SINGULARITY_DB_PASSWORD:-postgres}@db:5432/${SINGULARITY_DB_NAME:-singularity}
       LOTUS_TEST:
       LOTUS_API:
       LOTUS_TOKEN:
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:9091/health"]
+      test: ["CMD", "curl", "-f", "http://localhost:9090/health"]
       interval: 5s
       timeout: 5s
       retries: 5
@@ -135,7 +134,7 @@ services:
   motion:
     platform: linux/amd64
     image: ghcr.io/filecoin-project/motion:${MOTION_VERSION:-v0.2.3}
-    entrypoint: motion --experimentalSingularityStore --experimentalRemoteSingularityAPIUrl=singularity_api:9091 --experimentalSingularityContentURLTemplate=${SINGULARITY_CONTENT_PROVIDER_DOMAIN:-http://singularity_content_provider:7778}/piece/{PIECE_CID}
+    entrypoint: motion --experimentalSingularityStore --experimentalRemoteSingularityAPIUrl=singularity_api:9090 --experimentalSingularityContentURLTemplate=${SINGULARITY_CONTENT_PROVIDER_DOMAIN:-http://singularity_content_provider:7778}/piece/{PIECE_CID}
     ports:
       - 40080:40080
     environment:
@@ -182,7 +181,7 @@ services:
       motion:
         condition: service_started
       mongodb:
-        condition: service_started
+        condition: service_healthy
 
 volumes:
   motion-singularity-volume:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -27,9 +27,10 @@ services:
       MONGO_INITDB_ROOT_PASSWORD: ${MONGODB_AUTH_PASSWORD:-changeme}
       MONGO_INITDB_DATABASE: ${MONGODB_DATABASE:-metadata}
     ports:
-      - '27017:27017'
+      - 27017:27017
     volumes:
       - ${MOTION_HOME:-$HOME/.motion}/zenko/mongodbMetadata:/data/db
+      - ./mongod.conf:/etc/mongod.conf
 #    healthcheck:
 #      test: mongo --eval 'db.runCommand("ping").ok' localhost:27017/${MONGODB_DATABASE:-metadata} --quiet
 #      interval: 10s
@@ -37,13 +38,11 @@ services:
 #      retries: 10
 #      start_period: 30s
 
-  singularity_api:
+  singularity_admin_init:
     image: ghcr.io/data-preservation-programs/singularity:${SINGULARITY_VERSION:-v0.5.9}
-    command: run api --bind :9090
+    command: admin init
     volumes:
       - motion-singularity-volume:/usr/src/app/storage
-    ports:
-      - 9090:9090
     environment:
       DATABASE_CONNECTION_STRING: postgres://${SINGULARITY_DB_USER:-postgres}:${SINGULARITY_DB_PASSWORD:-postgres}@db:5432/${SINGULARITY_DB_NAME:-singularity}
       LOTUS_TEST:
@@ -52,6 +51,27 @@ services:
     depends_on:
       db:
         condition: service_healthy
+
+  singularity_api:
+    image: ghcr.io/data-preservation-programs/singularity:${SINGULARITY_VERSION:-v0.5.9}
+    command: run api --bind :9091
+    volumes:
+      - motion-singularity-volume:/usr/src/app/storage
+    ports:
+      - 9091:9091
+    environment:
+      DATABASE_CONNECTION_STRING: postgres://${SINGULARITY_DB_USER:-postgres}:${SINGULARITY_DB_PASSWORD:-postgres}@db:5432/${SINGULARITY_DB_NAME:-singularity}
+      LOTUS_TEST:
+      LOTUS_API:
+      LOTUS_TOKEN:
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9091/health"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    depends_on:
+      singularity_admin_init:
+        condition: service_completed_successfully
 
   singularity_dataset_worker:
     image: ghcr.io/data-preservation-programs/singularity:${SINGULARITY_VERSION:-v0.5.9}
@@ -64,8 +84,8 @@ services:
       LOTUS_API:
       LOTUS_TOKEN:
     depends_on:
-      db:
-        condition: service_healthy
+      singularity_admin_init:
+        condition: service_completed_successfully
 
   singularity_deal_pusher:
     image: ghcr.io/data-preservation-programs/singularity:${SINGULARITY_VERSION:-v0.5.9}
@@ -78,8 +98,8 @@ services:
       LOTUS_API:
       LOTUS_TOKEN:
     depends_on:
-      db:
-        condition: service_healthy
+      singularity_admin_init:
+        condition: service_completed_successfully
 
   singularity_deal_tracker:
     image: ghcr.io/data-preservation-programs/singularity:${SINGULARITY_VERSION:-v0.5.9}
@@ -91,9 +111,10 @@ services:
       LOTUS_TEST:
       LOTUS_API:
       LOTUS_TOKEN:
+      MARKET_DEAL_URL:
     depends_on:
-      db:
-        condition: service_healthy
+      singularity_admin_init:
+        condition: service_completed_successfully
 
   singularity_content_provider:
     image: ghcr.io/data-preservation-programs/singularity:${SINGULARITY_VERSION:-v0.5.9}
@@ -108,13 +129,13 @@ services:
       LOTUS_API:
       LOTUS_TOKEN:
     depends_on:
-      db:
-        condition: service_healthy
+      singularity_admin_init:
+        condition: service_completed_successfully
 
   motion:
     platform: linux/amd64
     image: ghcr.io/filecoin-project/motion:${MOTION_VERSION:-v0.2.3}
-    entrypoint: motion --experimentalSingularityStore --experimentalRemoteSingularityAPIUrl=http://singularity_api:9090 --experimentalSingularityContentURLTemplate=${SINGULARITY_CONTENT_PROVIDER_DOMAIN:-http://singularity_content_provider:7778}/piece/{PIECE_CID}
+    entrypoint: motion --experimentalSingularityStore --experimentalRemoteSingularityAPIUrl=singularity_api:9091 --experimentalSingularityContentURLTemplate=${SINGULARITY_CONTENT_PROVIDER_DOMAIN:-http://singularity_content_provider:7778}/piece/{PIECE_CID}
     ports:
       - 40080:40080
     environment:


### PR DESCRIPTION
this fixes the problems with singularity starting but i cannot figure out for the life of me how to get rid of this new error that shows up in cloudserver -

```
{"name":"S3","time":1699666065137,"error":"Server selection timed out after 30000 ms","level":"error","message":"error connecting to mongodb","hostname":"archlinux","pid":305189}
{"name":"S3","error":{"InternalError":true},"healthStatus":[null],"time":1699666065138,"req_id":"4b02ee911c4bb052599e","level":"info","message":"initial health check failed, delaying startup","hostname":"archlinux","pid":305189}
```

I've tried putting them on a network together, double checking all envs are passed through, and a lot of other stuff. i also verified that i can connect to mongo using the mongo cli just fine, it's just not working via cloudserver for some reason. honestly i'm gonna need help with this one. @gammazero any ideas?

the pr is set to merge into `gammazero/move-md-mongodb` fyi